### PR TITLE
docs: update external asset urls from v2-pixijs.com to pixijs.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ function ClickContainer() {
 
   return (
     <Sprite
-      texture={Texture.from('https://v2-pixijs.com/assets/bunny.png')}
+      texture={Texture.from('https://pixijs.com/assets/bunny.png')}
       interactive
       pointerdown={() => {
         setScale(s => s * 1.25)
@@ -40,7 +40,7 @@ function ClickContainer() {
 export function Click() {
   return (
     <Application background="#1099bb" resizeTo={window}>
-      <Assets load={[['https://v2-pixijs.com/assets/bunny.png']]}>
+      <Assets load={[['https://pixijs.com/assets/bunny.png']]}>
         <ClickContainer />
       </Assets>
     </Application>

--- a/packages/docs/src/components/AdvancedGraphics/AdvancedGraphics.tsx
+++ b/packages/docs/src/components/AdvancedGraphics/AdvancedGraphics.tsx
@@ -2,7 +2,7 @@ import { Sprite } from 'pixi.js'
 import { Application, Assets, Graphics } from '../../../../solid-pixi/src/index'
 
 export function GraphicsContainer() {
-  const sprite = Sprite.from('https://v2-pixijs.com/assets/bg_rotate.jpg')
+  const sprite = Sprite.from('https://pixijs.com/assets/bg_rotate.jpg')
   return (
     <>
       <Graphics
@@ -91,7 +91,7 @@ export function GraphicsContainer() {
 export function AdvancedGraphics() {
   return (
     <Application resizeTo={window}>
-      <Assets load={[['https://v2-pixijs.com/assets/bg_rotate.jpg']]}>
+      <Assets load={[['https://pixijs.com/assets/bg_rotate.jpg']]}>
         <GraphicsContainer />
       </Assets>
     </Application>

--- a/packages/docs/src/components/AnimatedSpriteExplosion/AnimatedSpriteExplosion.tsx
+++ b/packages/docs/src/components/AnimatedSpriteExplosion/AnimatedSpriteExplosion.tsx
@@ -36,7 +36,7 @@ function SwapContainer() {
 export function AnimatedSpriteExplosion() {
   return (
     <Application background="#1099bb" resizeTo={window}>
-      <Assets load={[['https://v2-pixijs.com/assets/spritesheet/mc.json']]}>
+      <Assets load={[['https://pixijs.com/assets/spritesheet/mc.json']]}>
         <SwapContainer />
       </Assets>
     </Application>

--- a/packages/docs/src/components/AnimatedSpriteSpeed/AnimatedSpriteSpeed.tsx
+++ b/packages/docs/src/components/AnimatedSpriteSpeed/AnimatedSpriteSpeed.tsx
@@ -20,7 +20,7 @@ function SpeedContainer() {
     const texture = Texture.from(framekey)
     const time = (
       (
-        pxAssets.get('https://v2-pixijs.com/assets/spritesheet/0123456789.json')
+        pxAssets.get('https://pixijs.com/assets/spritesheet/0123456789.json')
           .data as SpritesheetData
       ).frames[framekey] as any
     ).duration
@@ -57,7 +57,7 @@ function SpeedContainer() {
 export function AnimatedSpriteSpeed() {
   return (
     <Application resizeTo={window}>
-      <Assets load={[['https://v2-pixijs.com/assets/spritesheet/0123456789.json']]}>
+      <Assets load={[['https://pixijs.com/assets/spritesheet/0123456789.json']]}>
         <SpeedContainer />
       </Assets>
     </Application>

--- a/packages/docs/src/components/Assets/Assets.tsx
+++ b/packages/docs/src/components/Assets/Assets.tsx
@@ -24,17 +24,17 @@ export function AssetsLoading() {
                   {
                     name: 'flowerTop',
                     alias: 'flowerTop',
-                    src: 'https://v2-pixijs.com/assets/flowerTop.png'
+                    src: 'https://pixijs.com/assets/flowerTop.png'
                   },
                   {
                     name: 'sprites',
                     alias: 'sprites',
-                    src: 'https://v2-pixijs.com/assets/spritesheet/mc.png'
+                    src: 'https://pixijs.com/assets/spritesheet/mc.png'
                   },
                   {
                     name: 'spritesheet',
                     alias: 'spritesheet',
-                    src: 'https://v2-pixijs.com/assets/spritesheet/mc.json'
+                    src: 'https://pixijs.com/assets/spritesheet/mc.json'
                   }
                 ]
               },
@@ -44,7 +44,7 @@ export function AssetsLoading() {
                   {
                     name: 'eggHead',
                     alias: 'eggHead',
-                    src: 'https://v2-pixijs.com/assets/eggHead.png'
+                    src: 'https://pixijs.com/assets/eggHead.png'
                   }
                 ]
               }
@@ -54,8 +54,8 @@ export function AssetsLoading() {
         loadBundle={[`${state()}-screen`]}
         load={[
           [
-            'https://v2-pixijs.com/assets/eggHead.png',
-            'https://v2-pixijs.com/assets/webfont-loader/ChaChicle.ttf',
+            'https://pixijs.com/assets/eggHead.png',
+            'https://pixijs.com/assets/webfont-loader/ChaChicle.ttf',
             '/solid-pixi/json.json',
             '/solid-pixi/text.txt'
           ]

--- a/packages/docs/src/components/BitmapText/BitmapText.tsx
+++ b/packages/docs/src/components/BitmapText/BitmapText.tsx
@@ -28,7 +28,7 @@ function TextContainer() {
 export function BitmapText() {
   return (
     <Application background="#1099bb" resizeTo={window}>
-      <Assets load={[['https://v2-pixijs.com/assets/bitmap-font/desyrel.xml']]}>
+      <Assets load={[['https://pixijs.com/assets/bitmap-font/desyrel.xml']]}>
         <TextContainer />
       </Assets>
     </Application>

--- a/packages/docs/src/components/BlendModes/BlendModes.tsx
+++ b/packages/docs/src/components/BlendModes/BlendModes.tsx
@@ -13,7 +13,7 @@ import {
 function Dudes() {
   const parent = useParent()
   const app = useApplication()
-  const texture = Texture.from('https://v2-pixijs.com/assets/eggHead.png')
+  const texture = Texture.from('https://pixijs.com/assets/eggHead.png')
   const dudes = Array.from({ length: 20 }).map(() => {
     const scale = 0.8 + Math.random() * 0.3
     return {
@@ -87,7 +87,7 @@ function Background() {
   const app = useApplication()
   return (
     <Sprite
-      texture={Texture.from('https://v2-pixijs.com/assets/bg_rotate.jpg')}
+      texture={Texture.from('https://pixijs.com/assets/bg_rotate.jpg')}
       width={app?.stage.width}
       height={app?.stage.height}
     />
@@ -99,7 +99,7 @@ export function BlendModes() {
     <Application resizeTo={window}>
       <Assets
         load={[
-          ['https://v2-pixijs.com/assets/eggHead.png', 'https://v2-pixijs.com/assets/bg_rotate.jpg']
+          ['https://pixijs.com/assets/eggHead.png', 'https://pixijs.com/assets/bg_rotate.jpg']
         ]}
       >
         <Background />

--- a/packages/docs/src/components/Click/Click.tsx
+++ b/packages/docs/src/components/Click/Click.tsx
@@ -8,7 +8,7 @@ function ClickContainer() {
 
   return (
     <Sprite
-      texture={Texture.from('https://v2-pixijs.com/assets/bunny.png')}
+      texture={Texture.from('https://pixijs.com/assets/bunny.png')}
       interactive
       pointerdown={() => {
         setScale(s => s * 1.25)
@@ -24,7 +24,7 @@ function ClickContainer() {
 export function Click() {
   return (
     <Application background="#1099bb" resizeTo={window}>
-      <Assets load={[['https://v2-pixijs.com/assets/bunny.png']]}>
+      <Assets load={[['https://pixijs.com/assets/bunny.png']]}>
         <ClickContainer />
       </Assets>
     </Application>

--- a/packages/docs/src/components/Container/Container.tsx
+++ b/packages/docs/src/components/Container/Container.tsx
@@ -10,7 +10,7 @@ import {
 
 function BunniesContainer() {
   const app = useApplication()
-  const texture = Texture.from('https://v2-pixijs.com/assets/bunny.png')
+  const texture = Texture.from('https://pixijs.com/assets/bunny.png')
 
   return (
     <Container
@@ -47,7 +47,7 @@ function BunniesContainer() {
 export function ContainerExample() {
   return (
     <Application background="#1099bb" resizeTo={window}>
-      <Assets load={[['https://v2-pixijs.com/assets/bunny.png']]}>
+      <Assets load={[['https://pixijs.com/assets/bunny.png']]}>
         <BunniesContainer />
       </Assets>
     </Application>

--- a/packages/docs/src/components/CustomCursor/CustomCursor.tsx
+++ b/packages/docs/src/components/CustomCursor/CustomCursor.tsx
@@ -5,8 +5,8 @@ import { Application, Assets, Sprite, useApplication } from '../../../../solid-p
 function ClickContainer() {
   const app = useApplication()
 
-  const defaultIcon = "url('https://v2-pixijs.com/assets/bunny.png'),auto"
-  const hoverIcon = "url('https://v2-pixijs.com/assets/bunny_saturated.png'),auto"
+  const defaultIcon = "url('https://pixijs.com/assets/bunny.png'),auto"
+  const hoverIcon = "url('https://pixijs.com/assets/bunny_saturated.png'),auto"
 
   // Add custom cursor styles
   app.renderer.events.cursorStyles.default = defaultIcon
@@ -14,7 +14,7 @@ function ClickContainer() {
 
   return (
     <Sprite
-      texture={Texture.from('https://v2-pixijs.com/assets/bunny.png')}
+      texture={Texture.from('https://pixijs.com/assets/bunny.png')}
       interactive
       cursor={hoverIcon}
       scale={{ x: 3, y: 3 }}
@@ -31,8 +31,8 @@ export function CustomCursor() {
       <Assets
         load={[
           [
-            'https://v2-pixijs.com/assets/bunny.png',
-            'https://v2-pixijs.com/assets/bunny_saturated.png'
+            'https://pixijs.com/assets/bunny.png',
+            'https://pixijs.com/assets/bunny_saturated.png'
           ]
         ]}
       >

--- a/packages/docs/src/components/Dragging/Dragging.tsx
+++ b/packages/docs/src/components/Dragging/Dragging.tsx
@@ -4,7 +4,7 @@ import { Application, Assets, Sprite, useApplication } from '../../../../solid-p
 function DraggingContainer() {
   const app = useApplication()
 
-  const texture = Texture.from('https://v2-pixijs.com/assets/bunny.png')
+  const texture = Texture.from('https://pixijs.com/assets/bunny.png')
 
   let dragTarget = null
 
@@ -52,7 +52,7 @@ function DraggingContainer() {
 export function Dragging() {
   return (
     <Application background="#1099bb" resizeTo={window}>
-      <Assets load={[['https://v2-pixijs.com/assets/bunny.png']]}>
+      <Assets load={[['https://pixijs.com/assets/bunny.png']]}>
         <DraggingContainer />
       </Assets>
     </Application>

--- a/packages/docs/src/components/Interactivity/Interactivity.tsx
+++ b/packages/docs/src/components/Interactivity/Interactivity.tsx
@@ -5,9 +5,9 @@ import { Application, Assets, Sprite, useApplication } from '../../../../solid-p
 function InteractivityContainer() {
   const app = useApplication()
 
-  const textureButton = Texture.from('https://v2-pixijs.com/assets/button.png')
-  const textureButtonDown = Texture.from('https://v2-pixijs.com/assets/button_down.png')
-  const textureButtonOver = Texture.from('https://v2-pixijs.com/assets/button_over.png')
+  const textureButton = Texture.from('https://pixijs.com/assets/button.png')
+  const textureButtonDown = Texture.from('https://pixijs.com/assets/button_down.png')
+  const textureButtonOver = Texture.from('https://pixijs.com/assets/button_over.png')
 
   let isOver = false,
     isDown = false
@@ -65,9 +65,9 @@ export function Interactivity() {
       <Assets
         load={[
           [
-            'https://v2-pixijs.com/assets/button.png',
-            'https://v2-pixijs.com/assets/button_down.png',
-            'https://v2-pixijs.com/assets/button_over.png'
+            'https://pixijs.com/assets/button.png',
+            'https://pixijs.com/assets/button_down.png',
+            'https://pixijs.com/assets/button_over.png'
           ]
         ]}
       >

--- a/packages/docs/src/components/LoadingFonts/LoadingFonts.tsx
+++ b/packages/docs/src/components/LoadingFonts/LoadingFonts.tsx
@@ -3,10 +3,10 @@ import { For, Suspense } from 'solid-js'
 import { Application, Assets, Text } from '../../../../solid-pixi/src/index'
 
 const bundle = {
-  ChaChicle: 'https://v2-pixijs.com/assets/webfont-loader/ChaChicle.ttf',
-  Lineal: 'https://v2-pixijs.com/assets/webfont-loader/Lineal.otf',
-  'Dotrice Regular': 'https://v2-pixijs.com/assets/webfont-loader/Dotrice-Regular.woff',
-  Crosterian: 'https://v2-pixijs.com/assets/webfont-loader/Crosterian.woff2'
+  ChaChicle: 'https://pixijs.com/assets/webfont-loader/ChaChicle.ttf',
+  Lineal: 'https://pixijs.com/assets/webfont-loader/Lineal.otf',
+  'Dotrice Regular': 'https://pixijs.com/assets/webfont-loader/Dotrice-Regular.woff',
+  Crosterian: 'https://pixijs.com/assets/webfont-loader/Crosterian.woff2'
 }
 
 function Font(props: { fontFamily: string; y: number }) {

--- a/packages/docs/src/components/Spritesheet/Spritesheet.tsx
+++ b/packages/docs/src/components/Spritesheet/Spritesheet.tsx
@@ -38,14 +38,14 @@ export function Spritesheet() {
       <Assets
         load={[
           [
-            'https://v2-pixijs.com/assets/spritesheet/mc.png',
-            'https://v2-pixijs.com/assets/spritesheet/mc.json'
+            'https://pixijs.com/assets/spritesheet/mc.png',
+            'https://pixijs.com/assets/spritesheet/mc.json'
           ]
         ]}
       >
         <SpriteSheet
-          texture={Texture.from('https://v2-pixijs.com/assets/spritesheet/mc.png')}
-          data={pxAssets.get('https://v2-pixijs.com/assets/spritesheet/mc.json').data}
+          texture={Texture.from('https://pixijs.com/assets/spritesheet/mc.png')}
+          data={pxAssets.get('https://pixijs.com/assets/spritesheet/mc.json').data}
         >
           <SwapContainer />
         </SpriteSheet>

--- a/packages/docs/src/components/TextureSwap/TextureSwap.tsx
+++ b/packages/docs/src/components/TextureSwap/TextureSwap.tsx
@@ -11,8 +11,8 @@ import {
 function SwapContainer() {
   const app = useApplication()
   const textures = [
-    Texture.from('https://v2-pixijs.com/assets/flowerTop.png'),
-    Texture.from('https://v2-pixijs.com/assets/eggHead.png')
+    Texture.from('https://pixijs.com/assets/flowerTop.png'),
+    Texture.from('https://pixijs.com/assets/eggHead.png')
   ]
   const [texture, setTexture] = createSignal(0)
 
@@ -36,7 +36,7 @@ export function TextureSwap() {
     <Application background="#1099bb" resizeTo={window}>
       <Assets
         load={[
-          ['https://v2-pixijs.com/assets/flowerTop.png', 'https://v2-pixijs.com/assets/eggHead.png']
+          ['https://pixijs.com/assets/flowerTop.png', 'https://pixijs.com/assets/eggHead.png']
         ]}
       >
         <SwapContainer />

--- a/packages/docs/src/components/TilingSprite/TilingSprite.tsx
+++ b/packages/docs/src/components/TilingSprite/TilingSprite.tsx
@@ -4,7 +4,7 @@ import { Application, Assets, TilingSprite, useApplication } from '../../../../s
 
 function TilingSpriteContainer() {
   const app = useApplication()
-  const texture = Texture.from('https://v2-pixijs.com/assets/p2.jpeg')
+  const texture = Texture.from('https://pixijs.com/assets/p2.jpeg')
 
   let count = 0
 
@@ -31,7 +31,7 @@ function TilingSpriteContainer() {
 export function Example() {
   return (
     <Application resizeTo={window}>
-      <Assets load={[['https://v2-pixijs.com/assets/p2.jpeg']]}>
+      <Assets load={[['https://pixijs.com/assets/p2.jpeg']]}>
         <TilingSpriteContainer />
       </Assets>
     </Application>

--- a/packages/docs/src/components/Tinting/Tinting.tsx
+++ b/packages/docs/src/components/Tinting/Tinting.tsx
@@ -10,7 +10,7 @@ import {
 
 function Dudes() {
   const app = useApplication()
-  const texture = Texture.from('https://v2-pixijs.com/assets/eggHead.png')
+  const texture = Texture.from('https://pixijs.com/assets/eggHead.png')
   const dudes = Array.from({ length: 20 }).map(() => {
     const scale = 0.8 + Math.random() * 0.3
     return {
@@ -82,7 +82,7 @@ function Dudes() {
 export function Tinting() {
   return (
     <Application resizeTo={window}>
-      <Assets load={[['https://v2-pixijs.com/assets/eggHead.png']]}>
+      <Assets load={[['https://pixijs.com/assets/eggHead.png']]}>
         <Dudes />
       </Assets>
     </Application>

--- a/packages/docs/src/components/TransparentBackground/TransparentBackground.tsx
+++ b/packages/docs/src/components/TransparentBackground/TransparentBackground.tsx
@@ -4,7 +4,7 @@ import { Application, Assets, Sprite, useApplication } from '../../../../solid-p
 
 function BunniesContainer() {
   const app = useApplication()
-  const texture = Texture.from('https://v2-pixijs.com/assets/bunny.png')
+  const texture = Texture.from('https://pixijs.com/assets/bunny.png')
 
   return (
     <Sprite
@@ -26,7 +26,7 @@ function BunniesContainer() {
 export function TransparentBackground() {
   return (
     <Application backgroundAlpha={0} resizeTo={window}>
-      <Assets load={[['https://v2-pixijs.com/assets/bunny.png']]}>
+      <Assets load={[['https://pixijs.com/assets/bunny.png']]}>
         <BunniesContainer />
       </Assets>
     </Application>


### PR DESCRIPTION
I'm not familiar with the history of the pixijs site, but it seems like everything that previously was on v2-pixijs.com is now available on pixijs.com instead. This broke almost all of the examples.